### PR TITLE
Add Joi type to options passed to input components

### DIFF
--- a/src/FormSection.jsx
+++ b/src/FormSection.jsx
@@ -61,6 +61,7 @@ var FormSection = React.createClass({
                         ...fieldSchema._meta,
                         required: fieldSchema._flags.presence === 'required',
                         name: fieldName,
+                        type: fieldSchema._type,
                         label: fieldSchema._settings.language.label,
                         key: fieldName,
                         allowed: optionValues,


### PR DESCRIPTION
The 'type' property seemed to be missing from the options object. Adding this allowed a schema containing Joi.number(), Joi.date() to be displayed as the expected input types.
